### PR TITLE
added decoding encoding option and content type sniffing

### DIFF
--- a/django_logging/settings.py
+++ b/django_logging/settings.py
@@ -17,6 +17,8 @@ class DjangoLoggingSettings(object):
             IGNORED_PATHS=['/admin', '/static', '/favicon.ico'],
             RESPONSE_FIELDS=('status', 'reason', 'charset', 'headers', 'content'),
             CONTENT_JSON_ONLY=True,
+            CONTENT_TYPES=None,
+            ENCODING='ascii',
             ROTATE_MB=100,
             ROTATE_COUNT=10,
             INDENT_CONSOLE_LOG=2,
@@ -33,6 +35,13 @@ class DjangoLoggingSettings(object):
             self.__settings.update(user_settings)
         except TypeError:
             pass
+
+        self.__settings['LOG_PATH'] = os.path.join(django_settings.BASE_DIR, 'logs')
+
+        if self.CONTENT_JSON_ONLY:
+            self.__settings['CONTENT_TYPES'] = self.CONTENT_TYPES or []
+            self.__settings['CONTENT_TYPES'].append('application/json')
+
 
     def __getattr__(self, name):
         return self.__settings.get(name)

--- a/django_logging/settings.py
+++ b/django_logging/settings.py
@@ -36,8 +36,6 @@ class DjangoLoggingSettings(object):
         except TypeError:
             pass
 
-        self.__settings['LOG_PATH'] = os.path.join(django_settings.BASE_DIR, 'logs')
-
         if self.CONTENT_JSON_ONLY:
             self.__settings['CONTENT_TYPES'] = self.CONTENT_TYPES or []
             self.__settings['CONTENT_TYPES'].append('application/json')


### PR DESCRIPTION
- add `{ "ENCODING": "utf-8" }` to your config to enable unicode decoding
- optional list of `CONTENT_TYPES` to log
- don't decode and load json if content type not in `CONTENT_TYPES` (adds `'application/json'` if `CONTENT_JSON_ONLY`)
- `None` instead of excluding attribute vis try/except (@cipriantarta this is a matter of taste, so let me know if you'd like it reverted)
