### PR TITLE
Compatibility for MIDDLEWARE under django >= 1.10

### DIFF
--- a/django_logging/__init__.py
+++ b/django_logging/__init__.py
@@ -3,7 +3,7 @@ from . import logger
 from .log_object import LogObject, ErrorLogObject, SqlLogObject
 
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 __author__ = 'Ciprian Tarta'
 
 log = logger.get_logger()

--- a/django_logging/middleware.py
+++ b/django_logging/middleware.py
@@ -1,10 +1,11 @@
 from django.db import connections
+from django.utils.deprecation import MiddlewareMixin
 from . import log
 from . import settings
 from .log_object import LogObject, ErrorLogObject, SqlLogObject
 
 
-class DjangoLoggingMiddleware(object):
+class DjangoLoggingMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         error = ErrorLogObject(request, exception)
         log.error(error)


### PR DESCRIPTION
Django 1.10 introduces a new style MIDDLEWARE and this change adds
compatiblity for that while also allowing functionality under the old
MIDDLEWARE_CLASSES. Note that this should still break compatibility with Django
under <= 1.9.

See following Django docs for reference
https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware

Bumped version to `1.5.5`